### PR TITLE
Added 'www.datawrapper.de/_/' embed URL pattern to oEmbed providers.

### DIFF
--- a/datawrapper-oembed/datawrapper-oembed.php
+++ b/datawrapper-oembed/datawrapper-oembed.php
@@ -17,6 +17,7 @@ License: GPLv2 or later
 function datawrapper_oembed_provider() {
 
 	wp_oembed_add_provider( 'https://datawrapper.dwcdn.net/*', 'https://api.datawrapper.de/v3/oembed', false );
+	wp_oembed_add_provider( 'https://www.datawrapper.de/_/*', 'https://api.datawrapper.de/v3/oembed', false );
 
 }
 add_action( 'init', 'datawrapper_oembed_provider' );


### PR DESCRIPTION
The standard embed URLs now use the `www.datawrapper.de/_/` pattern, and it appears that the oembed provider service _is_ compatible with those URLs, so I've simply added a single line to allow embeds from those URLs.