### PR TITLE
chore(wpplugin): bump tested version

### DIFF
--- a/datawrapper-oembed/readme.txt
+++ b/datawrapper-oembed/readme.txt
@@ -2,7 +2,7 @@
 Contributors: drivenbydata
 Tags: oembed, data visualizaton
 Requires at least: 4.7
-Tested up to: 5.7.1
+Tested up to: 6.6.1
 Stable tag: 4.3
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
Our test WordPress instance runs on WP v6.6.1 and the plugin works. This PR just bumps the tested version.